### PR TITLE
fix clobbering of `op` CLI config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 [${version}]: https://github.com/westerveltco/django-opfield/releases/tag/v${version}
 -->
 
+## [Unreleased]
+
+### Fixed
+
+-   Removed the passing in of just the `OP_SERVICE_ACCOUNT_TOKEN` variable to the `subprocess.run` call to `op`. This was clobbering the environment and causing configuration issues with the `op` CLI. First reported in [#12](https://github.com/westerveltco/django-opfield/issues/12) by [@joshuadavidthomas](https://github.com/joshuadavidthomas).
+
 ## [0.1.0]
 
 Initial release! 🎉

--- a/src/django_opfield/fields.py
+++ b/src/django_opfield/fields.py
@@ -42,12 +42,12 @@ class OPField(models.CharField):
         def get_secret(self: models.Model) -> str | None:
             op = app_settings.get_op_cli_path()
             op_uri = getattr(self, name)
-            op_token = app_settings.get_op_service_account_token()
+            # call to check that the token is configured correctly
+            _ = app_settings.get_op_service_account_token()
             op_timeout = app_settings.OP_COMMAND_TIMEOUT
             result = subprocess.run(
                 [op, "read", op_uri],
                 capture_output=True,
-                env={"OP_SERVICE_ACCOUNT_TOKEN": op_token},
                 timeout=op_timeout,
             )
             if result.returncode != 0:

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -94,7 +94,6 @@ def test_get_secret(mock_run):
     mock_run.assert_called_once_with(
         [ANY, "read", "op://vault/item/field"],
         capture_output=True,
-        env=ANY,
         timeout=ANY,
     )
     assert secret == "secret value"
@@ -198,4 +197,4 @@ def test_command_timeout(mock_run):
     with pytest.raises(TimeoutExpired):
         _ = model.op_uri_secret
 
-    mock_run.assert_called_once_with(ANY, capture_output=True, env=ANY, timeout=1)
+    mock_run.assert_called_once_with(ANY, capture_output=True, timeout=1)


### PR DESCRIPTION
closes #12 