### PR TITLE
change to `RuntimeError` if `op` CLI not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+### Changed
+
+-   Changed exception raised if `op` CLI not found to `RuntimeError`.
+
 ### Fixed
 
 -   Removed the passing in of just the `OP_SERVICE_ACCOUNT_TOKEN` variable to the `subprocess.run` call to `op`. This was clobbering the environment and causing configuration issues with the `op` CLI. First reported in [#12](https://github.com/westerveltco/django-opfield/issues/12) by [@joshuadavidthomas](https://github.com/joshuadavidthomas).

--- a/src/django_opfield/conf.py
+++ b/src/django_opfield/conf.py
@@ -51,7 +51,7 @@ class AppSettings:
             path = shutil.which("op")
 
         if not path:
-            raise ImportError("Could not find the 'op' CLI command")
+            raise RuntimeError("Could not find the 'op' CLI command")
 
         return Path(path).resolve()
 

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -36,7 +36,7 @@ class TestGetOpCLIPath:
     def test_default(self, mock_which):
         mock_which.return_value = None
 
-        with pytest.raises(ImportError) as exc_info:
+        with pytest.raises(RuntimeError) as exc_info:
             assert app_settings.get_op_cli_path()
 
         assert "Could not find the 'op' CLI command" in str(exc_info.value)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -133,7 +133,7 @@ def test_get_secret_command_not_available(mock_which, db):
 
     model = OPFieldModel(op_uri="op://vault/item/field")
 
-    with pytest.raises(ImportError) as excinfo:
+    with pytest.raises(RuntimeError) as excinfo:
         _ = model.op_uri_secret
 
     assert "Could not find the 'op' CLI command" in str(excinfo.value)


### PR DESCRIPTION
closes #11 