### PR TITLE
:bookmark: bump version 0.1.0 -> 0.1.1

### DIFF
--- a/.copier/package.yml
+++ b/.copier/package.yml
@@ -3,7 +3,7 @@ _commit: v2024.19
 _src_path: gh:westerveltco/django-twc-package
 author_email: josh@joshthomas.dev
 author_name: Josh Thomas
-current_version: 0.1.0
+current_version: 0.1.1
 django_versions:
 - '4.2'
 - '5.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.1.1]
+
 ### Changed
 
 -   Changed exception raised if `op` CLI not found to `RuntimeError`.
@@ -54,5 +56,6 @@ Initial release! 🎉
 
 -   Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/westerveltco/django-opfield/compare/v0.1.0...HEAD
+[unreleased]: https://github.com/westerveltco/django-opfield/compare/v0.1.1...HEAD
 [0.1.0]: https://github.com/westerveltco/django-opfield/releases/tag/v0.1.0
+[0.1.1]: https://github.com/westerveltco/django-opfield/releases/tag/v0.1.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ Source = "https://github.com/westerveltco/django-opfield"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.1.0"
+current_version = "0.1.1"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_opfield/__init__.py
+++ b/src/django_opfield/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_opfield import __version__
 
 
 def test_version():
-    assert __version__ == "0.1.0"
+    assert __version__ == "0.1.1"


### PR DESCRIPTION
- `894f359`: fix clobbering of `op` CLI config (#13)
- `60eb511`: change to `RuntimeError` if `op` CLI not found (#14)
- `bf7f2da`: update changelog