### PR TITLE
:pencil: Spacing changes for docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,28 +19,28 @@ A custom Django field that integrates with the 1Password `op` CLI to securely ac
 
 1. Install the package from PyPI:
 
-   ```bash
-   python -m pip install django-opfield
-   ```
+    ```bash
+    python -m pip install django-opfield
+    ```
 
 2. Install the [1Password `op` CLI tool](https://developer.1password.com/docs/cli/get-started), making sure it is callable from wherever your application is running.
 
 3. Create a [1Password service account](https://developer.1password.com/docs/service-accounts/get-started) and make the service account's token available to your application.
 
-   Choose one option:
+    Choose one option:
 
-   - Set the `OP_SERVICE_ACCOUNT_TOKEN` environment variable
-   - Configure in your application's `settings.py`:
+    - Set the `OP_SERVICE_ACCOUNT_TOKEN` environment variable
+    - Configure in your application's `settings.py`:
 
-     ```python
-     # settings.py
-     DJANGO_OPFIELD = {
-         # Explicitly set here only as an example
-         # Use whatever configuration/environment library you prefer
-         # (`python-dotenv`, `django-environs`, `environs`, etc.)
-         "OP_SERVICE_ACCOUNT_TOKEN": "super-secret-token",
-     }
-     ```
+        ```python
+        # settings.py
+        DJANGO_OPFIELD = {
+            # Explicitly set here only as an example
+            # Use whatever configuration/environment library you prefer
+            # (`python-dotenv`, `django-environs`, `environs`, etc.)
+            "OP_SERVICE_ACCOUNT_TOKEN": "super-secret-token",
+        }
+        ```
 
 ## Usage
 


### PR DESCRIPTION
The editorconfig is already set to 4 spaces, so this just brings the README in line with that. This benefits mkdocs over in https://github.com/westerveltco/central-docs/