### PR TITLE
:bookmark: bump version 0.1.1 -> 0.2.0

### DIFF
--- a/.copier/package.yml
+++ b/.copier/package.yml
@@ -3,7 +3,7 @@ _commit: v2024.19
 _src_path: gh:westerveltco/django-twc-package
 author_email: josh@joshthomas.dev
 author_name: Josh Thomas
-current_version: 0.1.1
+current_version: 0.2.0
 django_versions:
 - '4.2'
 - '5.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.2.0]
+
 ### Added
 
 - Added support for Django 5.1 and 5.2.
@@ -64,6 +66,7 @@ Initial release! 🎉
 
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/westerveltco/django-opfield/compare/v0.1.1...HEAD
+[unreleased]: https://github.com/westerveltco/django-opfield/compare/v0.2.0...HEAD
 [0.1.0]: https://github.com/westerveltco/django-opfield/releases/tag/v0.1.0
 [0.1.1]: https://github.com/westerveltco/django-opfield/releases/tag/v0.1.1
+[0.2.0]: https://github.com/westerveltco/django-opfield/releases/tag/v0.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ Source = "https://github.com/westerveltco/django-opfield"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.1.1"
+current_version = "0.2.0"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_opfield/__init__.py
+++ b/src/django_opfield/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.1.1"
+__version__ = "0.2.0"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_opfield import __version__
 
 
 def test_version():
-    assert __version__ == "0.1.1"
+    assert __version__ == "0.2.0"


### PR DESCRIPTION
- `7818ce3`: [pre-commit.ci] pre-commit autoupdate (#25)
- `5af1ec7`: [pre-commit.ci] pre-commit autoupdate (#26)
- `b76ffc9`: [pre-commit.ci] pre-commit autoupdate (#27)
- `dda4a50`: :robot: :arrow_up: [pre-commit.ci] pre-commit autoupdate (#28)
- `3840f13`: [pre-commit.ci] pre-commit autoupdate (#29)
- `80df815`: [pre-commit.ci] pre-commit autoupdate (#30)
- `eac1031`: [pre-commit.ci] pre-commit autoupdate (#31)
- `f921c00`: [pre-commit.ci] pre-commit autoupdate (#32)
- `6d0d947`: [pre-commit.ci] pre-commit autoupdate (#33)
- `427e166`: :robot: [pre-commit.ci] pre-commit autoupdate (#34)
- `3e249e5`: :pencil: Indentation changes for docs (#35)
- `2e36375`: [pre-commit.ci] pre-commit autoupdate (#37)
- `6dc6def`: [pre-commit.ci] pre-commit autoupdate (#38)
- `df2b0d0`: :robot: [pre-commit.ci] pre-commit autoupdate (#39)
- `520e208`: [pre-commit.ci] pre-commit autoupdate (#40)
- `9cfca51`: [pre-commit.ci] pre-commit autoupdate (#41)
- `7005277`: [pre-commit.ci] pre-commit autoupdate (#42)
- `83b5522`: [pre-commit.ci] pre-commit autoupdate (#43)
- `7b68d30`: [pre-commit.ci] pre-commit autoupdate (#44)
- `3c5cdc3`: [pre-commit.ci] pre-commit autoupdate (#45)
- `ae7aaee`: [pre-commit.ci] pre-commit autoupdate (#46)
- `cc23620`: [pre-commit.ci] pre-commit autoupdate (#47)
- `4d94657`: [pre-commit.ci] pre-commit autoupdate (#48)
- `5e331af`: [pre-commit.ci] pre-commit autoupdate (#49)
- `1d178e7`: :robot: [pre-commit.ci] pre-commit autoupdate (#50)
- `746bd3a`: :robot: [pre-commit.ci] pre-commit autoupdate (#51)
- `22f2dc8`: [pre-commit.ci] pre-commit autoupdate (#52)
- `14faab3`: [pre-commit.ci] pre-commit autoupdate (#53)
- `b8f201f`: [pre-commit.ci] pre-commit autoupdate (#54)
- `910d373`: :robot: [pre-commit.ci] pre-commit autoupdate (#55)
- `c7ed159`: [pre-commit.ci] pre-commit autoupdate (#56)
- `9ba1758`: Drop support for Python 3.8 (#58)
- `7de8722`: bump Python min version for `main` Django (#59)
- `01eb47b`: remove labels workflow (#60)
- `9e5ffde`: [pre-commit.ci] pre-commit autoupdate (#57)
- `e0859be`: Add support for Django 5.1 (#61)
- `956c162`: Add support for Django 5.2 (#62)